### PR TITLE
fix: iOS 16

### DIFF
--- a/src/SW-DLT.jelly
+++ b/src/SW-DLT.jelly
@@ -322,7 +322,7 @@ if(args == nil) {
    exit()
 }
 
-list(items: ["cd $SHORTCUTS", "python SW_DLT.py ${mediaURL} ${args}"]) >> runScript
+list(items: ["python SW_DLT.py ${mediaURL} ${args}"]) >> runScript
 var scriptSource = """
 
 """


### PR DESCRIPTION
it seems that `cd $SHORTCUTS` is not supported in iOS 16. Removed this and app works.

For playlist downloading, More than 50mb music files is crashing. Not sure if shortcut related or what.