### PR TITLE
3.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ SW-DLT ("Shortcuts Wrapper for -DL Tools") is an iOS shortcut that allows you to
 
 ## Planned Features
 
+**NOTE**: Compatibility for iOS 17+ and new features are paused indefinitely, until I get new test devices. Support will be offered for bug fixes. If you can, donations are welcome at the [RoutineHub page](https://routinehub.co/shortcut/7284).
+
 - [X] Add standard progress bar
 
 - [X] Enable title grabbing for video, audio and playlists
@@ -27,13 +29,13 @@ SW-DLT ("Shortcuts Wrapper for -DL Tools") is an iOS shortcut that allows you to
 
 - [X] Migrate shortcut code to Jellycuts
 
-- [ ] Simplify dependency management & refreshes
+- [X] Simplify dependency management & refreshes
 
-- [ ] Add internal update management (for easier updating)
+- [ ] ~~Add internal update management (for easier updating)~~
 
-- [ ] Enable persistent user settings (including default save locations)
+- [ ] ~~Enable persistent user settings (including default save locations)~~
 
-- [ ] Allow file inputs with multiple URLs
+- [ ] ~~Allow file inputs with multiple URLs~~
 
 ## Disclaimers
 - Use this shortcut for downloading media you own or are authorized to download

--- a/src/SW-DLT.jelly
+++ b/src/SW-DLT.jelly
@@ -56,7 +56,8 @@ if(outputCode != nil) {
         // a-Shell full: getFile(fileName: fileName)
     } >> mediaFile
 
-    setName(input: mediaFile, name: fileTitle, dontIncludeExtension: false) >> finalMedia
+    replaceText(input: fileTitle, find: ".", replace: "_", isRegex: false, caseSensitive: false) >> safeTitle
+    setName(input: mediaFile, name: safeTitle, dontIncludeExtension: false) >> finalMedia
     quicklook(input: finalMedia)
 
     list(items: ["rm -rf SW_DLT*"]) >> cleanupCmd

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -361,7 +361,7 @@ def main():
 
     except Exception as exc_url:
         # All raised exceptions are handled here and send the user back to the shortcut with a message
-        if str(exc_url.args[0]) not in [Consts.DERROR_EXC, Consts.revalidate_EXC, Consts.ERASED_EXC]:
+        if str(exc_url.args[0]) not in [Consts.DERROR_EXC, Consts.ERASED_EXC]:
             return f'shortcuts://run-shortcut?name=SW-DLT&input=text&text={urllib.parse.quote(Consts.UNK_EXC)}'
         return f'shortcuts://run-shortcut?name=SW-DLT&input=text&text={urllib.parse.quote(str(exc_url.args[0]))}'
 

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -100,7 +100,6 @@ class SW_DLT:
             global yt_dlp
             import yt_dlp
 
-
         # If native FFmpeg is present, removes any web assembly version on device.
         if os.path.exists(f"{os.environ['APPDIR']}/bin/ffmpeg"):
             with contextlib.suppress(FileNotFoundError):

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -97,6 +97,7 @@ class SW_DLT:
         if revalidate:
             importlib.invalidate_caches()
             import requests
+            global yt_dlp
             import yt_dlp
 
 

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     pass
 
+
 # Constants class
 class Consts:
     CYELLOW, CGREEN, CBLUE, SBOLD, ENDL = "\033[93m", "\033[92m", "\033[94m", "\033[1m", "\033[0m"

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -13,6 +13,13 @@ import json
 import sys
 import os
 
+# Modules not shipped with Python, expected to fail on first run
+try:
+    import requests
+    import yt_dlp
+
+except ImportError:
+    pass
 
 # Constants class
 class Consts:

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -1,11 +1,11 @@
 # SW-DLT script, check Github for documentation.
 # Official release through RoutineHub, avoid unknown sources!
 
-import importlib.util
 import urllib.parse
 import contextlib
 import subprocess
 import mimetypes
+import importlib
 import datetime
 import hashlib
 import shutil
@@ -27,7 +27,7 @@ class Consts:
     CYELLOW, CGREEN, CBLUE, SBOLD, ENDL = "\033[93m", "\033[92m", "\033[94m", "\033[1m", "\033[0m"
     FFMPEG_URL = "https://github.com/holzschu/a-Shell-commands/releases/download/0.1/ffmpeg.wasm"
     FFPROBE_URL = "https://github.com/holzschu/a-Shell-commands/releases/download/0.1/ffprobe.wasm"
-    REBOOT_EXC = '{"output_code":"exception","exc_path":"vars.restartRequired"}'
+    revalidate_EXC = '{"output_code":"exception","exc_path":"vars.restartRequired"}'
     ERASED_EXC = '{"output_code":"exception","exc_path":"vars.erasedAll"}'
     DERROR_EXC = '{"output_code":"exception","exc_path":"vars.downloadError"}'
     UNK_EXC = '{"output_code":"exception","exc_path":"vars.unknownError"}'
@@ -44,6 +44,7 @@ class SW_DLT:
         self.file_id = file_id
         self.date_id = datetime.datetime.today().strftime("%d-%m-%y-%H-%M-%S")
         self.ytdlp_globals = {
+            "color": "never",
             "quiet": True,
             "no_warnings": True,
             "noprogress": True,
@@ -74,28 +75,28 @@ class SW_DLT:
 
     @staticmethod
     def validate_install():
-        reboot = False
+        revalidate = False
 
         show_progress("util", 0, 5)
         if importlib.util.find_spec("chardet") is None:
             subprocess.run("pip -q install chardet --disable-pip-version-check --upgrade")
-            reboot = True
+            revalidate = True
 
         show_progress("util", 1, 5)
         if importlib.util.find_spec("yt_dlp") is None:
             subprocess.run(
                 "pip -q install yt-dlp --disable-pip-version-check --upgrade --no-dependencies")
-            reboot = True
+            revalidate = True
 
         show_progress("util", 2, 5)
         if importlib.util.find_spec("gallery_dl") is None:
             subprocess.run(
                 "pip -q install gallery-dl --disable-pip-version-check --upgrade")
-            reboot = True
+            revalidate = True
 
         show_progress("util", 3, 5)
-        if reboot:
-            raise Exception(Consts.REBOOT_EXC)
+        if revalidate:
+            importlib.invalidate_caches()
 
         # If native FFmpeg is present, removes any web assembly version on device.
         if os.path.exists(f"{os.environ['APPDIR']}/bin/ffmpeg"):
@@ -358,7 +359,7 @@ def main():
 
     except Exception as exc_url:
         # All raised exceptions are handled here and send the user back to the shortcut with a message
-        if str(exc_url.args[0]) not in [Consts.DERROR_EXC, Consts.REBOOT_EXC, Consts.ERASED_EXC]:
+        if str(exc_url.args[0]) not in [Consts.DERROR_EXC, Consts.revalidate_EXC, Consts.ERASED_EXC]:
             return f'shortcuts://run-shortcut?name=SW-DLT&input=text&text={urllib.parse.quote(Consts.UNK_EXC)}'
         return f'shortcuts://run-shortcut?name=SW-DLT&input=text&text={urllib.parse.quote(str(exc_url.args[0]))}'
 

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -13,14 +13,6 @@ import json
 import sys
 import os
 
-# Modules not shipped with Python, expected to fail on first run
-try:
-    import requests
-    import yt_dlp
-
-except ImportError:
-    pass
-
 
 # Constants class
 class Consts:
@@ -96,6 +88,9 @@ class SW_DLT:
         show_progress("util", 3, 5)
         if revalidate:
             importlib.invalidate_caches()
+            import requests
+            import yt_dlp
+
 
         # If native FFmpeg is present, removes any web assembly version on device.
         if os.path.exists(f"{os.environ['APPDIR']}/bin/ffmpeg"):

--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -27,7 +27,6 @@ class Consts:
     CYELLOW, CGREEN, CBLUE, SBOLD, ENDL = "\033[93m", "\033[92m", "\033[94m", "\033[1m", "\033[0m"
     FFMPEG_URL = "https://github.com/holzschu/a-Shell-commands/releases/download/0.1/ffmpeg.wasm"
     FFPROBE_URL = "https://github.com/holzschu/a-Shell-commands/releases/download/0.1/ffprobe.wasm"
-    revalidate_EXC = '{"output_code":"exception","exc_path":"vars.restartRequired"}'
     ERASED_EXC = '{"output_code":"exception","exc_path":"vars.erasedAll"}'
     DERROR_EXC = '{"output_code":"exception","exc_path":"vars.downloadError"}'
     UNK_EXC = '{"output_code":"exception","exc_path":"vars.unknownError"}'

--- a/src/metadataJson.json
+++ b/src/metadataJson.json
@@ -1,5 +1,5 @@
 {
     "author": "net00",
     "rid": "7284",
-    "version": "3.18.2"
+    "version": "3.19"
 }

--- a/src/propertiesJson.json
+++ b/src/propertiesJson.json
@@ -9,7 +9,6 @@
         "noURL": "NA, use clipboard/Share Sheet",
         "deleteAllTitle": "Warning: Deleting All Dependencies",
         "deleteAllPrompt": "Deletion mode is ON. Are you sure you want to delete all dependencies?",
-        "restartRequired": "Required dependencies were installed in a-Shell. This process needed a one-time restart of the shortcut.",
         "downloadError": "The download encountered an error. Try (if applicable) using the default quality, updating internal dependencies, or reviewing provided login details.",
         "erasedAll": "All the dependencies used by this shortcut have been erased. They will be reinstalled & updated if a download is requested.",
         "unknownError": "An unknown error was encountered during execution. If you see this message repeatedly please raise an issue (repository in the about page).",

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -198,28 +198,6 @@ class TestSWDLT(unittest.TestCase):
         with self.assertRaisesRegex(Exception, exc_msg):
             pe_inst.run()
 
-    # @unittest.skip
-    def z_test_missing_dependencies(self):
-        # Tests installation of dependencies, must run after all other tests
-        print("TEST_MISSING_DEPENDENCIES")
-        url = "https://url.placeholder.com"
-        hash = "SW_DLT_MISSING_DEPS_ERROR_TEST"
-
-        subprocess.run("pip uninstall -y chardet")
-        subprocess.run("pip uninstall -y yt-dlp")
-        subprocess.run("pip uninstall -y gallery-dl")
-
-        exc_msg = '{"output_code":"exception","exc_path":"vars.restartRequired"}'
-
-        md_inst = SW_DLT(url, hash)
-        with self.subTest():
-            with self.assertRaisesRegex(Exception, exc_msg):
-                md_inst.validate_install()
-        with self.subTest():
-            self.assertEqual(True, importlib.util.find_spec("gallery_dl") is not None)
-        with self.subTest():
-            self.assertEqual(True, importlib.util.find_spec("yt_dlp") is not None)
-
     @classmethod
     def tearDownClass(cls):
         subprocess.run("rm -rf SW_DLT*")

--- a/util/templateRH.md
+++ b/util/templateRH.md
@@ -2,7 +2,9 @@
 
 **SW-DLT** ("Shortcuts Wrapper for -DL Tools") is an iOS shortcut that allows you to easily use, install and manage the popular and open source utilities **[`yt-dlp`](https://github.com/yt-dlp/yt-dlp)** and **[`gallery-dl`](https://github.com/mikf/gallery-dl)**.
 
-**Compatibility:** Works on iOS/iPadOS 16, 15, & 14
+**Compatibility:** Tested on iOS/iPadOS 14-16 
+
+**NOTE**: Compatibility for iOS 17+ and new features are paused indefinitely, until I get new test devices. Support will be offered for bug fixes. If you can, donations are welcome at the link below.
 
 **REQUIRED APP:**
 


### PR DESCRIPTION
- Fixed console coloring being overridden by yt-dlp
- Removed the need to restart after dependency installation
- Fixed issue where filenames with dots were not displayed as media