### PR TITLE
Fixed resume preview of long URLs

### DIFF
--- a/src/SW-DLT.plist
+++ b/src/SW-DLT.plist
@@ -142,7 +142,7 @@ GLOBAL SETTINGS INITIALIZATION</string>
 									<key>Value</key>
 									<dict>
 										<key>string</key>
-										<string>4.1</string>
+										<string>4.1.1</string>
 									</dict>
 									<key>WFSerializationType</key>
 									<string>WFTextTokenString</string>
@@ -3693,6 +3693,85 @@ fi</string>
 		</dict>
 		<dict>
 			<key>WFWorkflowActionIdentifier</key>
+			<string>is.workflow.actions.text.match</string>
+			<key>WFWorkflowActionParameters</key>
+			<dict>
+				<key>CustomOutputName</key>
+				<string>partUrlPreview</string>
+				<key>UUID</key>
+				<string>F1CD4012-F253-4762-ABD3-1A2C0B5791F8</string>
+				<key>WFMatchTextCaseSensitive</key>
+				<false/>
+				<key>WFMatchTextPattern</key>
+				<string>^.{120}</string>
+				<key>text</key>
+				<dict>
+					<key>Value</key>
+					<dict>
+						<key>attachmentsByRange</key>
+						<dict>
+							<key>{0, 1}</key>
+							<dict>
+								<key>Aggrandizements</key>
+								<array>
+									<dict>
+										<key>PropertyName</key>
+										<string>Keys</string>
+										<key>Type</key>
+										<string>WFPropertyVariableAggrandizement</string>
+									</dict>
+								</array>
+								<key>OutputName</key>
+								<string>partialDownload</string>
+								<key>OutputUUID</key>
+								<string>6AF9D25D-4808-42C9-A1EE-B038671EFD97</string>
+								<key>Type</key>
+								<string>ActionOutput</string>
+							</dict>
+						</dict>
+						<key>string</key>
+						<string>￼</string>
+					</dict>
+					<key>WFSerializationType</key>
+					<string>WFTextTokenString</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>WFWorkflowActionIdentifier</key>
+			<string>is.workflow.actions.gettext</string>
+			<key>WFWorkflowActionParameters</key>
+			<dict>
+				<key>CustomOutputName</key>
+				<string>partDisplayURL</string>
+				<key>UUID</key>
+				<string>C76EB77A-98F6-46AF-A012-3EA065D5AC38</string>
+				<key>WFTextActionText</key>
+				<dict>
+					<key>Value</key>
+					<dict>
+						<key>attachmentsByRange</key>
+						<dict>
+							<key>{0, 1}</key>
+							<dict>
+								<key>OutputName</key>
+								<string>partUrlPreview</string>
+								<key>OutputUUID</key>
+								<string>F1CD4012-F253-4762-ABD3-1A2C0B5791F8</string>
+								<key>Type</key>
+								<string>ActionOutput</string>
+							</dict>
+						</dict>
+						<key>string</key>
+						<string>￼...</string>
+					</dict>
+					<key>WFSerializationType</key>
+					<string>WFTextTokenString</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>WFWorkflowActionIdentifier</key>
 			<string>is.workflow.actions.gettext</string>
 			<key>WFWorkflowActionParameters</key>
 			<dict>
@@ -3708,19 +3787,10 @@ fi</string>
 						<dict>
 							<key>{85, 1}</key>
 							<dict>
-								<key>Aggrandizements</key>
-								<array>
-									<dict>
-										<key>PropertyName</key>
-										<string>Keys</string>
-										<key>Type</key>
-										<string>WFPropertyVariableAggrandizement</string>
-									</dict>
-								</array>
 								<key>OutputName</key>
-								<string>partialDownload</string>
+								<string>partDisplayURL</string>
 								<key>OutputUUID</key>
-								<string>6AF9D25D-4808-42C9-A1EE-B038671EFD97</string>
+								<string>C76EB77A-98F6-46AF-A012-3EA065D5AC38</string>
 								<key>Type</key>
 								<string>ActionOutput</string>
 							</dict>

--- a/src/SW-DLT.plist
+++ b/src/SW-DLT.plist
@@ -3703,7 +3703,7 @@ fi</string>
 				<key>WFMatchTextCaseSensitive</key>
 				<false/>
 				<key>WFMatchTextPattern</key>
-				<string>^.{120}</string>
+				<string>^.{0,120}</string>
 				<key>text</key>
 				<dict>
 					<key>Value</key>
@@ -3763,7 +3763,7 @@ fi</string>
 							</dict>
 						</dict>
 						<key>string</key>
-						<string>￼...</string>
+						<string>￼ -- </string>
 					</dict>
 					<key>WFSerializationType</key>
 					<string>WFTextTokenString</string>
@@ -3785,7 +3785,7 @@ fi</string>
 					<dict>
 						<key>attachmentsByRange</key>
 						<dict>
-							<key>{85, 1}</key>
+							<key>{65, 1}</key>
 							<dict>
 								<key>OutputName</key>
 								<string>partDisplayURL</string>
@@ -3796,9 +3796,9 @@ fi</string>
 							</dict>
 						</dict>
 						<key>string</key>
-						<string>SW-DLT: Partial/Unsaved Download
+						<string>SW-DLT: Unfinished Download!
 
-Would you like to resume or recover download from: ￼</string>
+Partial or unsaved download found: ￼ Would you like to resume it?</string>
 					</dict>
 					<key>WFSerializationType</key>
 					<string>WFTextTokenString</string>


### PR DESCRIPTION
Adds a limit of 120 characters to the URL preview shown when resuming a download option is offered. This fixes the following issues in which large URLs were shown and blocked the menu options from view:
- #100 
- #95 