### PR TITLE
Not specifying anymore that the browser type is Safari

### DIFF
--- a/src/SW_DLT.py
+++ b/src/SW_DLT.py
@@ -37,7 +37,6 @@ class SW_DLT:
             "noprogress": True,
             "progress_hooks": [show_progress],
             "postprocessor_hooks": [format_processing],
-            "cookiesfrombrowser": ("safari",)
         }
 
         processes = {
@@ -145,7 +144,7 @@ class SW_DLT:
         try:
             # Creating temp folder to store media
             os.makedirs(self.file_id, exist_ok=True)
-            dl_cmd = "gallery-dl {0} --range \"{1}\" --directory {2} --cookies-from-browser safari".format(
+            dl_cmd = "gallery-dl {0} --range \"{1}\" --directory {2}".format(
                 self.media_url, self.gallery_range, self.file_id)
                 
             with subprocess.Popen(dl_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True) as gdl:


### PR DESCRIPTION
yt-dlp's function `_extract_safari_cookies` throws an exception when `sys.platform` returns anything else than `"darwin"` (see https://github.com/yt-dlp/yt-dlp/blame/c96e9291ab7bd6e7da66d33424982c8b0b4431c7/yt_dlp/cookies.py#L559).

This function is called namely by the `extract_info` function.

Related to #103, #108, #110

~Unanswered question : why did the code work before ? Either `sys.platform` returned `"darwin"` until recently (seems unlikely), either `_extract_safari_cookies` wasn't called. Or maybe a third possibility.~
IIRC you already found the answer in #103

I didn't test this thoroughly yet, I'm not sure what the browser type was used for. If this PR is too fragile, then I can PR in yt-dlp for the underlying problem I guess.